### PR TITLE
adjust splitter re-size behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ packages
 ### DartEditor ###
 .project
 .buildlog
+.settings/

--- a/lib/main_app.html
+++ b/lib/main_app.html
@@ -40,6 +40,18 @@
       paper-menu-button {
         font-size: 0px;
       }
+
+      core-splitter {
+        background-color: #424b4b;
+        box-shadow: none;
+        color: #fff;
+        fill: #fff;
+      }
+
+      core-splitter:hover,
+      core-splitter:active {
+        background-color: #444;
+      }
     </style>
     <core-toolbar>
       <a href="http://dartlab.org" class="logo">&nbsp;</a>
@@ -67,14 +79,14 @@
     </core-toolbar>
     <div horizontal layout relative flex>
       <div flex vertical layout>
-        <code-editor label="HTML" value="{{body}}" flex></code-editor>
-        <core-splitter direction="up"></core-splitter>
+        <code-editor label="HTML" value="{{body}}"></code-editor>
+        <core-splitter direction="up" minSize="150px"></core-splitter>
         <code-editor label="Dart" value="{{dart}}" flex></code-editor>
       </div>
       <core-splitter direction="left"></core-splitter>
       <div flex vertical layout>
-        <code-editor label="CSS" value="{{css}}" flex></code-editor>
-        <core-splitter direction="up"></core-splitter>
+        <code-editor label="CSS" value="{{css}}"></code-editor>
+        <core-splitter direction="up" minSize="150px"></core-splitter>
         <dart-preview id="preview" body="{{body}}" css="{{css}}" dart="{{dart}}" fit?="{{isFullscreen}}" flex></dart-preview>
       </div>
     </div>


### PR DESCRIPTION
Adjust the splitter behavior:
- change the background color to match the page header
- let the two horizontal splitter be adjustable

I wasn't able to figure out a good way to set the initial splitter size. What I'd want to do is set something like `split="50%"` on the `core-splitter`. There's no api for that; perhaps polymer 0.8 will have a solution.

The `flex` attribute on the left-hand child causes the splitter to not be adjustable. Removing it lets the splitter adjust, but causes the initial position to be close to zero. I set a min size on the left hand child to partially compensate for that.

This PR isn't a total win-win but does improve the splitter behavior somewhat.
![screen shot 2015-02-09 at 12 08 10 pm](https://cloud.githubusercontent.com/assets/1269969/6114632/54d343f4-b054-11e4-9ba4-a9f51ae7916c.png)
